### PR TITLE
タスクを絞り込み・検索・ソートする機能の追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,23 +4,23 @@ class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_task, only: %i[show edit update destroy]
 
-  # GET /tasks or /tasks.json
   def index
-    @tasks = Task.all
+    query = Task.all
+    query = Task.search_keyword(search_params['keyword']) if search_params['keyword'].present?
+    query = Task.search_status(search_params['status']) if search_params['status'].present? && search_params['status'] != 'other'
+    query = Task.sort_by_keyword(search_params['sort']) if search_params['sort'].present?
+
+    @tasks = query
   end
 
-  # GET /tasks/1 or /tasks/1.json
   def show; end
 
-  # GET /tasks/new
   def new
     @task = Task.new
   end
 
-  # GET /tasks/1/edit
   def edit; end
 
-  # POST /tasks or /tasks.json
   def create
     @task = Task.new(task_params)
 
@@ -35,7 +35,6 @@ class TasksController < ApplicationController
     end
   end
 
-  # PATCH/PUT /tasks/1 or /tasks/1.json
   def update
     respond_to do |format|
       if @task.update(task_params)
@@ -48,7 +47,6 @@ class TasksController < ApplicationController
     end
   end
 
-  # DELETE /tasks/1 or /tasks/1.json
   def destroy
     @task.destroy
 
@@ -60,12 +58,14 @@ class TasksController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_task
     @task = Task.find(params[:id])
   end
 
-  # Only allow a list of trusted parameters through.
+  def search_params
+    params.permit(:keyword, :status, :sort)
+  end
+
   def task_params
     params.require(:task).permit(:name, :end_date, :priority, :status, :explanation).merge(user_id: current_user.id)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
 
   enum :priority, {
-    low: 0, # 低
+    low: 0,    # 低
     normal: 1, # 普通
     high: 2    # 高
   }, prefix: true
@@ -16,4 +16,15 @@ class Task < ApplicationRecord
     touched: 1,   # 着手中
     completed: 2  # 完了
   }, prefix: true
+
+  SORT_TYPE = {
+    'id_asc' => 'tasks.id ASC',
+    'id_desc' => 'tasks.id DESC',
+    'name_asc' => 'tasks.name ASC',
+    'name_desc' => 'tasks.name DESC'
+  }.freeze
+
+  scope :search_keyword, ->(keyword) { where('CONCAT(name, explanation) LIKE ?', "%#{sanitize_sql_like(keyword)}%") }
+  scope :search_status, ->(status) { where(status:) }
+  scope :sort_by_keyword, ->(sort) { order(SORT_TYPE[sort]) }
 end

--- a/app/views/tasks/_search_form.html.erb
+++ b/app/views/tasks/_search_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with(url: tasks_path, method: :get, local: true) do |form| %>
+  <div>
+    <%= form.label :keyword, style: "display: block" %>
+    <%= form.text_field :keyword %>
+  </div>
+
+  <div>
+    <%= form.label :status, style: "display: block" %>
+    <%= form.select :status, ['other', 'untouched', 'touched', 'completed'] %>
+  </div>
+
+  <div>
+    <%= form.label :sort, style: "display: block" %>
+    <%= form.select :sort, ['id_asc', 'id_desc', 'name_asc', 'name_desc'] %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,6 +4,14 @@
 
 <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
 
+<h2>Search Form</h2>
+
+<%= render "search_form" %>
+
+<h2>Tasks Index</h2>
+
+<%= link_to "New task", new_task_path %>
+
 <div id="tasks">
   <% @tasks.each do |task| %>
     <%= render task %>
@@ -12,5 +20,3 @@
     </p>
   <% end %>
 </div>
-
-<%= link_to "New task", new_task_path %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    stdin_open: true
+    tty: true
     volumes:
       - .:/myapp
     ports:

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -29,4 +29,78 @@ RSpec.describe Task, type: :model do
       ).with_prefix
     }
   end
+
+  describe 'scope' do
+    describe 'search_keyword' do
+      let!(:first_task) { create(:task, name: 'タスク', explanation: '説明文') }
+      let!(:second_task) { create(:task, name: 'ラスク', explanation: 'タスク') }
+      let!(:third_task) { create(:task, name: 'リスク', explanation: 'にゃんこ') }
+
+      subject { Task.search_keyword(keyword) }
+
+      context 'when exist search_keyword' do
+        let(:keyword) { 'タスク' }
+
+        it 'search from name or explanation' do
+          is_expected.to eq [first_task, second_task]
+        end
+      end
+    end
+
+    describe 'search_status' do
+      let!(:first_task) { create(:task, status: 'untouched') }
+      let!(:second_task) { create(:task, status: 'touched') }
+      let!(:third_task) { create(:task, status: 'untouched') }
+
+      subject { Task.search_status(status) }
+
+      context 'when exist search_status' do
+        let(:status) { 'untouched' }
+
+        it 'search from specified status' do
+          is_expected.to eq [first_task, third_task]
+        end
+      end
+    end
+
+    describe 'sort_by_keyword' do
+      let!(:first_task) { create(:task, name: 'ううう') }
+      let!(:second_task) { create(:task, name: 'あああ') }
+      let!(:third_task) { create(:task, name: 'いいい') }
+
+      subject { Task.sort_by_keyword(sort) }
+
+      context 'when sort type is id_asc' do
+        let(:sort) { 'id_asc' }
+
+        it 'sort by specified sort type' do
+          is_expected.to eq [first_task, second_task, third_task]
+        end
+      end
+
+      context 'when sort type is id_desc' do
+        let(:sort) { 'id_desc' }
+
+        it 'sort by specified sort type' do
+          is_expected.to eq [third_task, second_task, first_task]
+        end
+      end
+
+      context 'when sort type is name_asc' do
+        let(:sort) { 'name_asc' }
+
+        it 'sort by specified sort type' do
+          is_expected.to eq [second_task, third_task, first_task]
+        end
+      end
+
+      context 'when sort type is name_desc' do
+        let(:sort) { 'name_desc' }
+
+        it 'sort by specified sort type' do
+          is_expected.to eq [first_task, third_task, second_task]
+        end
+      end
+    end
+  end
 end

--- a/spec/views/tasks/index.html.erb_spec.rb
+++ b/spec/views/tasks/index.html.erb_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe 'tasks/index', type: :view do
   it 'renders a list of tasks' do
     render
 
+    assert_select 'form[action=?][method=?]', tasks_path, 'get' do
+      assert_select 'input[name=?]', 'keyword'
+      assert_select 'select[name=?]', 'status'
+      assert_select 'select[name=?]', 'sort'
+    end
+
     tasks.each do |task|
       expect(rendered).to match(/#{task.name}/)
       expect(rendered).to match(/#{task.end_date}/)


### PR DESCRIPTION
行ったこと
- ステータスで絞り込み
- タスク名と説明文で検索
- ソートを行う(id, nameを昇順または降順で)